### PR TITLE
Add commit history to issue view

### DIFF
--- a/components/com_code/models/issue.php
+++ b/components/com_code/models/issue.php
@@ -39,6 +39,31 @@ class CodeModelIssue extends JModelLegacy
 		}
 	}
 
+	public function getCommits($issueId = null)
+	{
+		$issueId = empty($issueId) ? JFactory::getApplication()->input->getInt('issue_id') : $issueId;
+
+		$db = $this->getDbo();
+
+		$db->setQuery(
+			$db->getQuery(true)
+				->select('a.*, cu.first_name, cu.last_name')
+				->from('#__code_tracker_issue_commits AS a')
+				->join('LEFT', '#__code_users AS cu ON cu.user_id = a.created_by')
+				->where('a.jc_issue_id = ' . (int) $issueId)
+				->order('a.created_date ASC')
+		);
+
+		try
+		{
+			return $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			JError::raiseError(500, 'Unable to access resource: ' . $e->getMessage());
+		}
+	}
+
 	public function getItem($issueId = null)
 	{
 		$issueId = empty($issueId) ? JFactory::getApplication()->input->getInt('issue_id') : $issueId;

--- a/components/com_code/views/issue/tmpl/default.php
+++ b/components/com_code/views/issue/tmpl/default.php
@@ -49,4 +49,20 @@ JHtml::_('stylesheet', 'com_code/default.css', array(), true);
 				<?php endforeach; ?>
 		</div>
 	<?php endif; ?>
+
+	<?php if (!empty($this->commits)) : ?>
+		<div class="issue-commits">
+			<h4>Commits</h4>
+			<?php foreach ($this->commits as $commit) : ?>
+				<div class="issue-commits">
+					<span class="commit-owner">
+						Commit made on <?php echo JHtml::_('date', $commit->created_date, 'j M Y, G:s'); ?> by <?php echo $commit->first_name . ' ' . $commit->last_name; ?>
+					</span>
+					<div class="issue-commit-details">
+						<?php echo nl2br($commit->message); ?>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
 </div>

--- a/components/com_code/views/issue/view.html.php
+++ b/components/com_code/views/issue/view.html.php
@@ -29,6 +29,7 @@ class CodeViewIssue extends JViewLegacy
 		$this->state    = $model->getState();
 		$this->item     = $model->getItem();
 		$this->tags     = $model->getTags();
+		$this->commits  = $model->getCommits();
 		$this->comments = $model->getComments($this->item->issue_id);
 		$this->user     = JFactory::getUser();
 		$this->params   = JFactory::getApplication()->getParams('com_code');


### PR DESCRIPTION
Displays the commits for an associated issue. I just ran the sync tool for the 1.0 issues (as that seemed to be the default) and there were only 15 entries in the ```#__code_tracker_issue_commits``` table. So I guess that we aren't going to have many of these :/

I'm not sure where to position this. Maybe rather than having it in it's own section I guess better would to add the commits in with the repsonses? Give a type to comments and commits so you can render them slightly differently. Thoughts?