### PR TITLE
Menu link in wrong place

### DIFF
--- a/administrator/components/com_code/code.xml
+++ b/administrator/components/com_code/code.xml
@@ -9,7 +9,6 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0-dev</version>
 	<description>COM_CODE_XML_DESCRIPTION</description>
-	<menu link="option=com_code">COM_CODE</menu>
 
 	<install>
 		<sql>
@@ -45,6 +44,7 @@
 	</media>
 
 	<administration>
+		<menu link="option=com_code">COM_CODE</menu>
 		<files folder="admin">
 			<folder>helpers</folder>
 			<folder>install</folder>


### PR DESCRIPTION
Needs to be in the administrator xml tag to create the admin menu item (currently on 3.4 and higher doesn't show thanks to a certain @mbabker 's 'b/c break' :P 