### PR TITLE
A small admin section to manage tracker names and descriptions

### DIFF
--- a/administrator/components/com_code/code.xml
+++ b/administrator/components/com_code/code.xml
@@ -46,6 +46,7 @@
 	<administration>
 		<menu link="option=com_code">COM_CODE</menu>
 		<files folder="admin">
+			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>install</folder>
 			<folder>language</folder>

--- a/administrator/components/com_code/code.xml
+++ b/administrator/components/com_code/code.xml
@@ -49,6 +49,7 @@
 			<folder>helpers</folder>
 			<folder>install</folder>
 			<folder>language</folder>
+			<folder>models</folder>
 			<folder>tables</folder>
 			<folder>views</folder>
 			<filename>access.xml</filename>

--- a/administrator/components/com_code/controllers/trackers.json.php
+++ b/administrator/components/com_code/controllers/trackers.json.php
@@ -16,24 +16,34 @@ class CodeControllerTrackers extends JControllerLegacy
 {
 	public function save()
 	{
-		$model = $this->getModel('Trackers');
-		var_dump($this->input->post->getString('title'));die;
+		$model     = $this->getModel('Trackers');
+		$inputData = $this->input->post->get('tracker', array(), 'array');
+		$filter    = JFilterInput::getInstance();
 
 		$data = array(
-			'jc_tracker_id' => $tracker->tracker_id,
-			'title'         => $tracker->tracker_name,
-			'description'   => $tracker->description
+			'tracker_id'    => $filter->clean($inputData['id'], 'int'),
+			'jc_tracker_id' => $filter->clean($inputData['jc_tracker_id'], 'int'),
+			'title'         => $filter->clean($inputData['title'], 'string'),
+			'description'   => $filter->clean($inputData['description'], 'html')
 		);
 
 		try
 		{
-			$result = $model->save();
+			$result = $model->save($data);
 		}
 		catch (Exception $e)
 		{
-			$result = $e;
+			$result       = false;
+
+			// Enqueue the message for JResponseJson to pick up on if asked.
+			JFactory::getApplication()->enqueueMessage($e->getMessage());
 		}
 
-		echo new JResponseJson($result, null, false, $this->input->get('ignoreMessages', true, 'bool'));
+		$return = array(
+			'result' => $result,
+			'data'   => $data
+		);
+
+		echo new JResponseJson($return, null, false, $this->input->get('ignoreMessages', true, 'bool'));
 	}
 }

--- a/administrator/components/com_code/controllers/trackers.json.php
+++ b/administrator/components/com_code/controllers/trackers.json.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_code
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Trackers Controller for Joomla Code
+ */
+class CodeControllerTrackers extends JControllerLegacy
+{
+	public function save()
+	{
+		$model = $this->getModel('Trackers');
+		var_dump($this->input);die;
+
+		$data = array(
+			'jc_tracker_id' => $tracker->tracker_id,
+			'title'         => $tracker->tracker_name,
+			'description'   => $tracker->description
+		);
+
+		try
+		{
+			$result = $model->save();
+		}
+		catch (Exception $e)
+		{
+			$result = $e;
+		}
+
+		echo new JResponseJson($result, null, false, $this->input->get('ignoreMessages', true, 'bool'));
+	}
+}

--- a/administrator/components/com_code/controllers/trackers.json.php
+++ b/administrator/components/com_code/controllers/trackers.json.php
@@ -17,7 +17,7 @@ class CodeControllerTrackers extends JControllerLegacy
 	public function save()
 	{
 		$model = $this->getModel('Trackers');
-		var_dump($this->input);die;
+		var_dump($this->input->post->getString('title'));die;
 
 		$data = array(
 			'jc_tracker_id' => $tracker->tracker_id,

--- a/administrator/components/com_code/helpers/code.php
+++ b/administrator/components/com_code/helpers/code.php
@@ -30,7 +30,7 @@ class CodeHelper extends JHelperContent
 		);
 
 		JHtmlSidebar::addEntry(
-			'Trackers',
+			JText::_('COM_CODE_TRACKERS'),
 			'index.php?option=com_code&view=trackers',
 			$vName == 'trackers'
 		);

--- a/administrator/components/com_code/helpers/code.php
+++ b/administrator/components/com_code/helpers/code.php
@@ -28,5 +28,11 @@ class CodeHelper extends JHelperContent
 			'index.php?option=com_code&view=about',
 			$vName == 'about'
 		);
+
+		JHtmlSidebar::addEntry(
+			'Trackers',
+			'index.php?option=com_code&view=trackers',
+			$vName == 'trackers'
+		);
 	}
 }

--- a/administrator/components/com_code/language/en-GB/en-GB.com_code.ini
+++ b/administrator/components/com_code/language/en-GB/en-GB.com_code.ini
@@ -12,3 +12,4 @@ COM_CODE_XML_DESCRIPTION="Component synchronizing data with JoomlaCode and other
 COM_CODE_ABOUT_TITLE="Joomla! Code Component - About"
 COM_CODE_ABOUT="About"
 COM_CODE_TRACKERS_TITLE="Joomla! Code Component - Trackers"
+COM_CODE_TRACKERS="Trackers"

--- a/administrator/components/com_code/language/en-GB/en-GB.com_code.ini
+++ b/administrator/components/com_code/language/en-GB/en-GB.com_code.ini
@@ -8,3 +8,5 @@ COM_CODE_COMPONENT_CONFIG="Component Configuration"
 COM_CODE_CONFIG_EMAIL_ERROR_DESC="A comma separated list of users to e-mail when a cron job has an error."
 COM_CODE_CONFIG_EMAIL_ERROR_LABEL="E-mail Users On Error"
 COM_CODE_XML_DESCRIPTION="Component synchronizing data with JoomlaCode and other admin tasks"
+
+COM_CODE_TRACKERS_TITLE="Joomla! Code Component - Trackers"

--- a/administrator/components/com_code/models/trackers.php
+++ b/administrator/components/com_code/models/trackers.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_code
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Trackers Model for Joomla Code
+ */
+class CodeModelTrackers extends JModelLegacy
+{
+	public function getItems()
+	{
+		// Initialize variables.
+		$items = array();
+
+		// Get the list of active branches.
+		$this->_db->setQuery(
+			'SELECT a.*' .
+			' FROM #__code_trackers AS a' .
+//			' WHERE a.published = 1' .
+			' ORDER BY a.title ASC'
+		);
+		$items = $this->_db->loadObjectList();
+
+		if ($this->_db->getErrorNum())
+		{
+			JError::raiseError(500, 'Unable to access resource.');
+		}
+
+		return $items;
+	}
+}

--- a/administrator/components/com_code/models/trackers.php
+++ b/administrator/components/com_code/models/trackers.php
@@ -35,4 +35,11 @@ class CodeModelTrackers extends JModelLegacy
 
 		return $items;
 	}
+
+	public function save($data)
+	{
+		$table = $this->getTable('Tracker', 'CodeTable');
+
+		return $table->save($data);
+	}
 }

--- a/administrator/components/com_code/views/trackers/tmpl/default.php
+++ b/administrator/components/com_code/views/trackers/tmpl/default.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_code
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+
+<div id="j-sidebar-container" class="span2">
+	<?php echo $this->sidebar; ?>
+</div>
+<div id="j-main-container" class="span10">
+</div>

--- a/administrator/components/com_code/views/trackers/tmpl/default.php
+++ b/administrator/components/com_code/views/trackers/tmpl/default.php
@@ -35,18 +35,25 @@ tinymce.init({
 
 function saveData()
 {
-	var trackerItem = {};
 	jQuery(".tracker").each(function() {
 		// Clear any variables set in the variable
-		trackerItem=[];
-		trackerItem["tracker[id]"] = jQuery(this).data("tracker-id");
-		trackerItem["tracker[title]"] = jQuery(this).find("h3").eq(0).text();
-		trackerItem["tracker[description]"] =  jQuery(this).find(".tracker-description").eq(0).text();
-		console.log(trackerItem);
+		console.log(
+		{
+			"tracker[id]": jQuery(this).data("tracker-id"),
+			"tracker[jc_tracker_id]": jQuery(this).data("tracker-jc-id"),
+			"tracker[title]": jQuery(this).find("h3").eq(0).text(),
+			"tracker[description]": jQuery(this).find(".tracker-description").eq(0).text()
+		}
+		);
 		jQuery.ajax({ 
 			type:"POST",
 			url:'index.php?option=com_code&task=trackers.save&format=json',
-			data: trackerItem,
+			data: {
+				"tracker[id]": jQuery(this).data("tracker-id"),
+				"tracker[jc_tracker_id]": jQuery(this).data("tracker-jc-id"),
+				"tracker[title]": jQuery(this).find("h3").eq(0).text(),
+				"tracker[description]": jQuery(this).find(".tracker-description").eq(0).text()
+			},
 			success:function(response){
 				// TODO: Display a success message to the user
 				console.log(response);
@@ -74,7 +81,7 @@ function saveData()
 		<form class="adminForm">
 			<div class="trackers">
 				<?php foreach ($this->trackers as $tracker) : ?>
-					<div class="tracker" data-tracker-id="<?php echo $tracker->tracker_id; ?>">
+					<div class="tracker" data-tracker-id="<?php echo $tracker->tracker_id; ?>" data-tracker-jc-id="<?php echo $tracker->jc_tracker_id; ?>">
 						<h3 class="editable"><?php echo $tracker->title; ?></h3>
 						<div class="tracker-description editable">
 							<?php echo $tracker->description; ?>

--- a/administrator/components/com_code/views/trackers/tmpl/default.php
+++ b/administrator/components/com_code/views/trackers/tmpl/default.php
@@ -32,6 +32,33 @@ tinymce.init({
     ],
     toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
 });
+
+function saveData()
+{
+	var Items = [];
+	var trackerItem = [];
+	jQuery(".tracker").each(function() {
+		// Clear any variables set in the variable
+		trackerItem=[];
+		trackerItem["id"] = jQuery(this).data("tracker-id");
+		trackerItem["title"] = jQuery(this).find("h3").eq(0).text();
+		trackerItem["description"] =  jQuery(this).find(".tracker-description").eq(0).text();
+		Items.push(trackerItem);
+		jQuery.ajax({ 
+			type:"POST",
+			url:'index.php?option=com_code&task=trackers.save&format=json',
+			data: Items,
+			success: function(){
+				var messages = {
+					"success": ["Tracker data saved successfully"]
+				};
+				Joomla.renderMessages(messages);
+			}
+		});
+	});
+
+	return false;
+}
 </script>
 
 <div id="j-sidebar-container" class="span2">
@@ -46,7 +73,7 @@ tinymce.init({
 		<form class="adminForm">
 			<div class="trackers">
 				<?php foreach ($this->trackers as $tracker) : ?>
-					<div class="tracker" id="tracker<?php echo $tracker->tracker_id; ?>">
+					<div class="tracker" data-tracker-id="<?php echo $tracker->tracker_id; ?>">
 						<h3 class="editable"><?php echo $tracker->title; ?></h3>
 						<div class="tracker-description editable">
 							<?php echo $tracker->description; ?>
@@ -54,6 +81,7 @@ tinymce.init({
 					</div>
 				<?php endforeach; ?>
 			</div>
+			<button type="submit" class="btn btn-danger" onClick="return saveData();">Save tracker information</button>
 		</form>
 	<?php endif;?>
 </div>

--- a/administrator/components/com_code/views/trackers/tmpl/default.php
+++ b/administrator/components/com_code/views/trackers/tmpl/default.php
@@ -35,24 +35,25 @@ tinymce.init({
 
 function saveData()
 {
-	var Items = [];
-	var trackerItem = [];
+	var trackerItem = {};
 	jQuery(".tracker").each(function() {
 		// Clear any variables set in the variable
 		trackerItem=[];
-		trackerItem["id"] = jQuery(this).data("tracker-id");
-		trackerItem["title"] = jQuery(this).find("h3").eq(0).text();
-		trackerItem["description"] =  jQuery(this).find(".tracker-description").eq(0).text();
-		Items.push(trackerItem);
+		trackerItem["tracker[id]"] = jQuery(this).data("tracker-id");
+		trackerItem["tracker[title]"] = jQuery(this).find("h3").eq(0).text();
+		trackerItem["tracker[description]"] =  jQuery(this).find(".tracker-description").eq(0).text();
+		console.log(trackerItem);
 		jQuery.ajax({ 
 			type:"POST",
 			url:'index.php?option=com_code&task=trackers.save&format=json',
-			data: Items,
-			success: function(){
-				var messages = {
-					"success": ["Tracker data saved successfully"]
-				};
-				Joomla.renderMessages(messages);
+			data: trackerItem,
+			success:function(response){
+				// TODO: Display a success message to the user
+				console.log(response);
+			},
+			error:function(error){
+				// TODO: Display appropriate error message
+				console.log(error);
 			}
 		});
 	});

--- a/administrator/components/com_code/views/trackers/tmpl/default.php
+++ b/administrator/components/com_code/views/trackers/tmpl/default.php
@@ -8,10 +8,52 @@
  */
 
 defined('_JEXEC') or die;
+
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
+
+<script type="text/javascript" src="<?php echo JUri::root() . '/media/editors/tinymce/'; ?>tinymce.min.js"></script>
+<script type="text/javascript">
+tinymce.init({
+    selector: "h3.editable",
+    inline: true,
+    toolbar: "undo redo",
+    menubar: false
+});
+
+tinymce.init({
+    selector: "div.editable",
+    inline: true,
+    plugins: [
+        "advlist autolink lists link image charmap print preview anchor",
+        "searchreplace visualblocks code fullscreen",
+        "insertdatetime media table contextmenu paste"
+    ],
+    toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+});
+</script>
 
 <div id="j-sidebar-container" class="span2">
 	<?php echo $this->sidebar; ?>
 </div>
 <div id="j-main-container" class="span10">
+	<?php if (empty($this->trackers)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
+		<form class="adminForm">
+			<div class="trackers">
+				<?php foreach ($this->trackers as $tracker) : ?>
+					<div class="tracker" id="tracker<?php echo $tracker->tracker_id; ?>">
+						<h3 class="editable"><?php echo $tracker->title; ?></h3>
+						<div class="tracker-description editable">
+							<?php echo $tracker->description; ?>
+						</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</form>
+	<?php endif;?>
 </div>

--- a/administrator/components/com_code/views/trackers/view.html.php
+++ b/administrator/components/com_code/views/trackers/view.html.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_code
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * View to show the about screen.
+ */
+class CodeViewTrackers extends JViewLegacy
+{
+	/**
+	 * The necessary HTML to display the sidebar
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
+
+	/**
+	 * Execute and display a template script.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
+	 *
+	 * @return  mixed  A string if successful, otherwise a Error object.
+	 */
+	public function display($tpl = null)
+	{
+		CodeHelper::addSubmenu('trackers');
+
+		$this->addToolbar();
+		$this->sidebar = JHtmlSidebar::render();
+
+		return parent::display($tpl);
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 *
+	 * @return  void
+	 */
+	protected function addToolbar()
+	{
+		$canDo = CodeHelper::getActions('com_code');
+
+		JToolBarHelper::title(JText::_('COM_CODE_TRACKERS_TITLE'), 'trackers');
+
+		if ($canDo->get('core.admin'))
+		{
+			JToolBarHelper::divider();
+			JToolBarHelper::preferences('com_code');
+		}
+	}
+}

--- a/administrator/components/com_code/views/trackers/view.html.php
+++ b/administrator/components/com_code/views/trackers/view.html.php
@@ -30,6 +30,10 @@ class CodeViewTrackers extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
+		/** @var CodeModelTrackers $model */
+		$model = $this->getModel();
+		$this->trackers = $model->getItems();
+		$this->state    = $model->getState();
 		CodeHelper::addSubmenu('trackers');
 
 		$this->addToolbar();


### PR DESCRIPTION
Uses the inline editor of tinymce (available since tiny 4 but not currently used in the CMS). Edit inline the title and description of trackers and then click the submit button.